### PR TITLE
Explicitly import Base operators

### DIFF
--- a/src/Ratios.jl
+++ b/src/Ratios.jl
@@ -1,6 +1,6 @@
 module Ratios
 
-import Base: convert, promote_rule
+import Base: convert, promote_rule, *, /, +, -, ^, ==
 
 export SimpleRatio
 


### PR DESCRIPTION
Avoids deprecation warnings on v0.4 master.