### PR TITLE
Add conversions and promotion rules with Rationals

### DIFF
--- a/src/Ratios.jl
+++ b/src/Ratios.jl
@@ -15,6 +15,8 @@ function convert{T<:FloatingPoint,S}(::Type{T}, r::SimpleRatio{S})
     convert(T, convert(P, r.num)/convert(P, r.den))
 end
 convert{T<:Integer}(::Type{SimpleRatio{T}}, i::Integer) = SimpleRatio{T}(convert(T, i), one(T))
+convert{T<:Integer, S<:Integer}(::Type{SimpleRatio{T}}, r::Rational{S}) = SimpleRatio(convert(T, r.num), convert(T, r.den))
+convert{T<:Integer, S<:Integer}(::Type{Rational{T}}, r::SimpleRatio{S}) = convert(T, r.num) // convert(T, r.den)
 
 *(x::SimpleRatio, y::SimpleRatio) = SimpleRatio(x.num*y.num, x.den*y.den)
 *(x::SimpleRatio, y::Bool) = SimpleRatio(x.num*y, x.den)
@@ -36,6 +38,7 @@ convert{T<:Integer}(::Type{SimpleRatio{T}}, i::Integer) = SimpleRatio{T}(convert
 promote_rule{T<:Integer,S<:Integer}(::Type{SimpleRatio{T}}, ::Type{S}) = SimpleRatio{promote_type(T,S)}
 promote_rule{T<:Integer,S<:Integer}(::Type{SimpleRatio{T}}, ::Type{SimpleRatio{S}}) = SimpleRatio{promote_type(T,S)}
 promote_rule{T<:Integer,S<:FloatingPoint}(::Type{SimpleRatio{T}}, ::Type{S}) = promote_type(T,S)
+promote_rule{T<:Integer,S<:Integer}(::Type{SimpleRatio{T}}, ::Type{Rational{S}}) = Rational{promote_type(T,S)}
 
 ==(x::SimpleRatio, y::SimpleRatio) = x.num*y.den == x.den*y.num
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,3 +28,7 @@ r2 = SimpleRatio(2,3)
 @test_throws OverflowError -SimpleRatio(0x02,0x03)
 
 @test r + SimpleRatio(0x02,0x03) == SimpleRatio(7,6)
+
+@test Rational{Int}(11,10) == 11//10
+@test SimpleRatio{Int}(11//10) == 11//10
+@test 1//3 + SimpleRatio(1,5) == 8//15

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,5 @@ r2 = SimpleRatio(2,3)
 
 @test r + SimpleRatio(0x02,0x03) == SimpleRatio(7,6)
 
-@test Rational{Int}(11,10) == 11//10
-@test SimpleRatio{Int}(11//10) == 11//10
-@test 1//3 + SimpleRatio(1,5) == 8//15
+@test SimpleRatio(11, 10) == 11//10
+@test 1//3 + SimpleRatio(1, 5) == 8//15


### PR DESCRIPTION
I stumbled upon this when writing some tests for Interpolations.jl. Specifically, the following failed:

```
julia> R = Rational{Int}[x^2//10 for x in 1:10];
julia> itp = interpolate(R, BSpline(Quadratic(Free)), OnCell)
ERROR: LoadError: MethodError: `convert` has no method matching convert(::Type{Rational{Int64}}, ::Ratios.SimpleRatio{Int64})
This may have arisen from a call to the constructor Rational{Int64}(...),
since type constructors fall back to convert methods.
Closest candidates are:
  call{T}(::Type{T}, ::Any)
  convert{T<:Real}(::Type{T<:Real}, ::Complex{T<:Real})
  convert{T<:Integer}(::Type{Rational{T<:Integer}}, ::Rational{T<:Integer})
  ...
```

With the changes in this PR, the above works (and indexing into the interpolation object yields reasonable results).