### PR TITLE
Compose SimpleRatio and SaferIntegers

### DIFF
--- a/src/Ratios.jl
+++ b/src/Ratios.jl
@@ -72,6 +72,11 @@ function __init__()
         SimpleRatio(x::FixedPoint) = SimpleRatio(reinterpret(x), rawone_noerr(x))
         Base.convert(::Type{S}, x::FixedPoint) where S<:SimpleRatio = S(x)
     end
+    @require SaferIntegers = "88634af6-177f-5301-88b8-7819386cfa38" begin
+        using .SaferIntegers: SafeSigned, SafeUnsigned
+        -(x::SimpleRatio{T}) where {T<:SafeSigned} = SimpleRatio(-x.num, x.den)
+        -(x::SimpleRatio{T}) where {T<:SafeUnsigned} = throw(VERSION < v"0.7.0-DEV.1269" ? OverflowError() : OverflowError("cannot negate unsigned number"))
+    end
 end
 
 end


### PR DESCRIPTION
This pull request composes Ratios with SaferIntegers in order to detect overflow errors.

`SafeSigned` and `SafeUnsigned` in `SaferIntegers` are not subtypes of `Signed` and `Unsigned`, respectively. Therefore, the additive inverse method is not defined in Ratios.jl for these types resulting in a `MethodError`.

`SafeSigned` and `SafeUnsigned`are subtypes of `SafeInteger` and `Integer`, so the other methods are defined.

```julia
julia> using Ratios, SaferIntegers

julia> -SimpleRatio{SafeInt}(1,5)
ERROR: MethodError: no method matching -(::SimpleRatio{SafeInt64})
...
julia> -SimpleRatio{SafeUInt}(1,5)
ERROR: MethodError: no method matching -(::SimpleRatio{SafeUInt64})
...
```

This pull request adds methods to take the additive inverse of `SimpleRatio`s based on `SafeInt` and `SafeUInt`:
```julia
julia> -SimpleRatio{SafeInt}(1,5)
SimpleRatio{SafeInt64}(-1, 5)

julia> -SimpleRatio{SafeUInt}(1,5)
ERROR: OverflowError: cannot negate unsigned number
Stacktrace:
 [1] -(x::SimpleRatio{SafeUInt64})
   @ Ratios ~\.julia\dev\Ratios\src\Ratios.jl:78
...
```

After the addition of these methods integer overflow can be detected in Interpolations.jl as in https://github.com/JuliaMath/Interpolations.jl/issues/457

```julia
julia> using Interpolations

julia> itpi = LinearInterpolation(SafeInt[1,10000],SafeInt[1,10000]; extrapolation_bc=Line())
2-element extrapolate(interpolate((::Vector{SafeInt64},), ::Vector{SafeInt64}, Gridded(Linear())), Line()) with element type Float64:
 SimpleRatio{SafeInt64}(99980001, 99980001)
 SimpleRatio{SafeInt64}(999800010000, 99980001)

julia> itpi(10001)
ERROR: OverflowError: 999800010000 * 99980001 overflowed for type Int64
Stacktrace:
 [1] throw_overflowerr_binaryop(op::Symbol, x::Int64, y::Int64)
   @ Base.Checked .\checked.jl:154
 [2] checked_mul
   @ .\checked.jl:288 [inlined]
 [3] *
   @ ~\.julia\packages\SaferIntegers\zbJSp\src\arith_ops.jl:21 [inlined]
 [4] +
   @ ~\.julia\dev\Ratios\src\Ratios.jl:35 [inlined]
 [5] extrapolate_axis
   @ ~\.julia\dev\Interpolations\src\extrapolation\extrapolation.jl:168 [inlined]
 [6] extrapolate_value
   @ ~\.julia\dev\Interpolations\src\extrapolation\extrapolation.jl:162 [inlined]
 [7] (::Interpolations.Extrapolation{Float64, 1, Interpolations.GriddedInterpolation{Float64, 1, SafeInt64, Gridded{Linear{Throw{OnGrid}}}, Tuple{Vector{SafeInt64}}}, Gridded{Linear{Throw{OnGrid}}}, Line{Nothing}})(x::Int64)
   @ Interpolations ~\.julia\dev\Interpolations\src\extrapolation\extrapolation.jl:52
 [8] top-level scope
   @ REPL[6]:1
```

Additionally a test suite is added to test the integration of the two packages.