### PR TITLE
use an extension for FixedPointNumbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,9 +6,16 @@ version = "0.4.3"
 [deps]
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
+[weakdeps]
+FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+
 [compat]
+FixedPointNumbers = "0.8"
 Requires = "1"
 julia = "0.7, 1"
+
+[extensions]
+RatiosFixedPointNumbersExt = "FixedPointNumbers"
 
 [extras]
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"

--- a/ext/RatiosFixedPointNumbersExt.jl
+++ b/ext/RatiosFixedPointNumbersExt.jl
@@ -1,0 +1,16 @@
+module RatiosFixedPointNumbersExt
+
+using Ratios
+isdefined(Base, :get_extension) ? (using FixedPointNumbers) : (using ..FixedPointNumbers)
+
+using .FixedPointNumbers: FixedPoint, Fixed, Normed, rawone
+
+rawone_noerr(::Type{Fixed{T,f}}) where {T,f} = widen(oneunit(T)) << f
+rawone_noerr(::Type{N}) where N<:Normed = rawone(N)
+rawone_noerr(x::FixedPoint) = rawone_noerr(typeof(x))
+Base.promote_rule(::Type{SimpleRatio{S}}, ::Type{<:FixedPoint{T}}) where {S<:Integer,T<:Integer} = SimpleRatio{promote_type(S, T)}
+Ratios.SimpleRatio{S}(x::FixedPoint) where S<:Integer = SimpleRatio{S}(reinterpret(x), rawone_noerr(x))
+Ratios.SimpleRatio(x::FixedPoint) = SimpleRatio(reinterpret(x), rawone_noerr(x))
+Base.convert(::Type{S}, x::FixedPoint) where S<:SimpleRatio = S(x)
+
+end

--- a/src/Ratios.jl
+++ b/src/Ratios.jl
@@ -12,7 +12,6 @@ module Ratios
 
 import Base: convert, promote_rule, *, /, +, -, ^, ==, decompose
 
-using Requires
 
 export SimpleRatio, common_denominator
 
@@ -121,17 +120,17 @@ function common_denominator(x::SimpleRatio, ys::SimpleRatio...)
     end
 end
 
+
+if !isdefined(Base, :get_extension)
+    using Requires
+end
+
+@static if !isdefined(Base, :get_extension)
 function __init__()
     @require FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93" begin
-        using .FixedPointNumbers: FixedPoint, Fixed, Normed, rawone
-        rawone_noerr(::Type{Fixed{T,f}}) where {T,f} = widen(oneunit(T)) << f
-        rawone_noerr(::Type{N}) where N<:Normed = rawone(N)
-        rawone_noerr(x::FixedPoint) = rawone_noerr(typeof(x))
-        Base.promote_rule(::Type{SimpleRatio{S}}, ::Type{<:FixedPoint{T}}) where {S<:Integer,T<:Integer} = SimpleRatio{promote_type(S, T)}
-        SimpleRatio{S}(x::FixedPoint) where S<:Integer = SimpleRatio{S}(reinterpret(x), rawone_noerr(x))
-        SimpleRatio(x::FixedPoint) = SimpleRatio(reinterpret(x), rawone_noerr(x))
-        Base.convert(::Type{S}, x::FixedPoint) where S<:SimpleRatio = S(x)
+        include("../ext/RatiosFixedPointNumbersExt.jl")
     end
+end
 end
 
 end


### PR DESCRIPTION
Before (in a temp env):

```julia
julia> @time using FixedPointNumbers
  0.074205 seconds (77.63 k allocations: 4.738 MiB)

julia> @time using Ratios
  0.412248 seconds (46.21 k allocations: 3.182 MiB, 7.24% compilation time)
```

After:

```julia
julia> @time using FixedPointNumbers
  0.023623 seconds (78.35 k allocations: 4.792 MiB)

julia> @time using Ratios
  0.008980 seconds (7.18 k allocations: 494.305 KiB, 28.47% compilation time)

julia> Base.get_extension(Ratios, :RatiosFixedPointNumbersExt)
RatiosFixedPointNumbersExt
```